### PR TITLE
[Fix] gabs library evolutions no more Consume method replaced by Wrap…

### DIFF
--- a/realtime/messages.go
+++ b/realtime/messages.go
@@ -1,11 +1,11 @@
 package realtime
 
 import (
-	"github.com/gopackage/ddp"
+	"fmt"
+
 	"github.com/Jeffail/gabs"
 	"github.com/detached/gorocket/api"
-	"log"
-	"fmt"
+	"github.com/gopackage/ddp"
 )
 
 const (
@@ -49,18 +49,13 @@ func (c *Client) SubscribeToMessageStream(channel *api.Channel) (chan api.Messag
 }
 
 func getMessageFromData(data interface{}) *api.Message {
-	document, _ := gabs.Consume(data)
+	document := gabs.Wrap(data)
 	return getMessageFromDocument(document)
 }
 
 func getMessagesFromUpdateEvent(update ddp.Update) []api.Message {
-	document, _ := gabs.Consume(update["args"])
-	args, err := document.Children()
-
-	if err != nil {
-		log.Printf("Event arguments are in an unexpected format: %v", err)
-		return make([]api.Message, 0)
-	}
+	document := gabs.Wrap(update["args"])
+	args := document.Children()
 
 	messages := make([]api.Message, len(args))
 


### PR DESCRIPTION
… + Consume and Children don't return error

Migration to v2 : https://github.com/Jeffail/gabs/blob/master/migration.md